### PR TITLE
build: add empty lines into `release.md`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -89,8 +89,10 @@ createReleaseBody.configure {
   doLast {
     outputFile.delete()
     outputFile << """SpotBugs ${project.version}
+
 ### CHANGELOG
 - https://github.com/spotbugs/spotbugs/blob/${project.version}/CHANGELOG.md
+
 ### CHECKSUM
 | file | checksum (sha256) |
 | ---- | ----------------- |


### PR DESCRIPTION
In the following change, I removed necessary empty lines mistakenly,
so GitHub Release wasn't generated properly.

https://github.com/spotbugs/spotbugs/commit/2d1f69b5a6fe05bee0e50714e44f1784c56c3111#diff-49a96e7eea8a94af862798a45174e6ac43eb4f8b4bd40759b5da63ba31ec3ef7L90



----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
