### PR TITLE
build(deps): bump org.ajoberstar.grgit from 1.7.2 to 4.1.0

### DIFF
--- a/eclipsePlugin/build.gradle
+++ b/eclipsePlugin/build.gradle
@@ -3,7 +3,7 @@ import static groovy.io.FileType.FILES
 // TODO: deploy not only jar but also sources and javadoc, to pass validation by Sonatype nexus
 // apply from: "$rootDir/gradle/maven.gradle"
 plugins {
-  id 'org.ajoberstar.grgit' version '1.7.2'
+  id 'org.ajoberstar.grgit' version '4.1.0'
 }
 
 def readLastCommitHash() {


### PR DESCRIPTION
Bumps org.ajoberstar.grgit from 1.7.2 to 4.1.0.

Signed-off-by: dependabot[bot] <support@github.com>



----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
