### PR TITLE
fix: support Java 14 by using ASM version 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Currently the versioning policy of this project follows [Semantic Versioning v2.
 ## Unreleased - 2020-??-??
 ### Fixed
 * False positive `RCN_REDUNDANT_NULLCHECK_OF_NONNULL_VALUE` on try-with-resources ([#259](https://github.com/spotbugs/spotbugs/issues/259))
+* Misconfiguration which makes ASM not supporting Java 14 ([#1276](https://github.com/spotbugs/spotbugs/issues/1276))
 
 ## 4.1.2 - 2020-08-18
 ### Fixed

--- a/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/asm/FindBugsASM.java
+++ b/spotbugs/src/main/java/edu/umd/cs/findbugs/classfile/engine/asm/FindBugsASM.java
@@ -28,6 +28,6 @@ public class FindBugsASM {
 
     private static final boolean USE_EXPERIMENTAL = Boolean.parseBoolean(System.getProperty("spotbugs.experimental", "true"));
 
-    public static final int ASM_VERSION = Opcodes.ASM7;
+    public static final int ASM_VERSION = Opcodes.ASM8;
 
 }


### PR DESCRIPTION
ASM 8.0.1 provides support for Java 14. We need to bump up
the field in FindBugsASM.java to enable this new features.



----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
