### PR TITLE
ci: fix release build in the master branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
           echo ossrhUsername=eller86 >> gradle.properties
           echo "ossrhPassword=${SONATYPE_PASSWORD}" >> gradle.properties
           echo "keystorepass=${KEYSTORE_PASS}" >> gradle.properties
-          ./gradlew assemble publish --no-daemon --parallel
+          ./gradlew assemble publish createReleaseBody --no-daemon --parallel
         env:
           GPG_SECRET_PASSPHRASE: ${{ secrets.GPG_SECRET_PASSPHRASE }}
           SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}

--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,10 @@ import org.gradle.crypto.checksum.Checksum
 
 def createReleaseBody = tasks.register("createReleaseBody")
 def createChecksums = tasks.register("createChecksums", Checksum)
+def publishTask = tasks.findByName("publish")
+if (publishTask == null) {
+  publishTask = tasks.findByName("publishToMavenLocal")
+}
 def outputFile = file("$buildDir/release.md")
 def inputFile =  subprojects.collect {
   it.hasProperty('publishing') ? it.publishing.publications.maven.artifacts : []
@@ -95,8 +99,10 @@ def inputFile =  subprojects.collect {
 }
 
 createChecksums.configure {
-  mustRunAfter assemble
   files = files(inputFile)
+  if (publishTask != null) {
+    dependsOn publishTask
+  }
 }
 createReleaseBody.configure {
   inputs.files fileTree("$buildDir/checksums").matching {
@@ -126,10 +132,6 @@ createReleaseBody.configure {
       outputFile << "| ${ name } | ${hash[0]} |\n"
     }
   }
-}
-
-project.getTasksByName("publish", true).forEach {
-  it.dependsOn createReleaseBody
 }
 
 apply from: "$rootDir/gradle/sonar.gradle"


### PR DESCRIPTION
the target files to create checksum are created by `publish` task,
not `assemble` task. we need to invoke `publish` in advance
to generate checksum.



----

Make sure these boxes are checked before submitting your PR -- thank you!

- [x] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
