### PR TITLE
docs: add a missing ja document for #1183

### DIFF
--- a/spotbugs/etc/messages_ja.xml
+++ b/spotbugs/etc/messages_ja.xml
@@ -172,6 +172,13 @@ SpotBugs の以前のバージョンでは，このカテゴリは Style とし�
   Detectors
   **********************************************************************
    -->
+  <Detector class="edu.umd.cs.findbugs.detect.OverridingMethodsMustInvokeSuperDetector">
+    <Details>
+      <![CDATA[
+<p>オーバーライドしているメソッドのうち、スーパークラスのメソッドを呼び出すべきものを見つけます。</p>
+]]>
+    </Details>
+  </Detector>
   <Detector class="edu.umd.cs.findbugs.detect.FindRoughConstants">
     <Details>
 <![CDATA[
@@ -2005,6 +2012,15 @@ FindNullDeref ディテクタで，非 <code>null</code> 値だけが使われ�
   **********************************************************************
   -->
 
+  <BugPattern type="OVERRIDING_METHODS_MUST_INVOKE_SUPER">
+    <ShortDescription>スーパークラスのメソッドが @OverridingMethodsMustInvokeSuper で修飾されていますが, オーバーライドしているメソッドはスーパークラスのメソッドを呼び出していません。</ShortDescription>
+    <LongDescription>スーパークラスのメソッドが @OverridingMethodsMustInvokeSuper で修飾されていますが, {1}はスーパークラスのメソッドを呼び出していません。</LongDescription>
+    <Details>
+      <![CDATA[
+    <p>スーパークラスのメソッドが @OverridingMethodsMustInvokeSuper で修飾されていますが, オーバーライドしているメソッドはスーパークラスのメソッドを呼び出していません。</p>
+]]>
+    </Details>
+  </BugPattern>
   <BugPattern type="CNT_ROUGH_CONSTANT_VALUE">
     <ShortDescription>既知の定数の雑な値を見つけた</ShortDescription>
     <LongDescription>{3} の雑な値を見つけました: {2}</LongDescription>


### PR DESCRIPTION
missing document makes the build of Japanese docs failing
https://readthedocs.org/projects/spotbugs-ja/builds/11359742/



----

Make sure these boxes are checked before submitting your PR -- thank you!

- [ ] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
