### PR TITLE
build: pack log4j-api to distribution

### DIFF
--- a/spotbugs/build.gradle
+++ b/spotbugs/build.gradle
@@ -5,9 +5,7 @@ apply from: "$rootDir/gradle/javadoc.gradle"
 
 configurations {
   // used only in distribution. It is not listed in pom.xml, so users like maven plugin don't use this dependency.
-  logBinding {
-    transitive = false
-  }
+  logBinding
 }
 
 ext {
@@ -93,7 +91,9 @@ dependencies {
   }
   api 'org.slf4j:slf4j-api:1.8.0-beta4'
   implementation 'net.sf.saxon:Saxon-HE:10.1'
-  logBinding 'org.apache.logging.log4j:log4j-slf4j18-impl:2.13.3'
+  logBinding ('org.apache.logging.log4j:log4j-slf4j18-impl:2.13.3') {
+    exclude group: 'org.slf4j'
+  }
 
   // These annotations are repackaged to spotbugs.jar, to keep backward compatibility for Ant task.
   // If they're not repackaged, Ant task will report 'java.lang.ClassNotFoundException: edu.umd.cs.findbugs.annotations.CleanupObligation'


### PR DESCRIPTION
c70db23d28b31a9f562029c6244243342ac804ce solves duplicated
slf4j-api problem, but it introduced missing log4j-api problem
because log4j binding depends on not only slf4j-api but also
log4j-api.
https://mvnrepository.com/artifact/org.apache.logging.log4j/log4j-slf4j18-impl/2.13.1



----

Make sure these boxes are checked before submitting your PR -- thank you!

- [ ] Added an entry into `CHANGELOG.md` if you have changed SpotBugs code
